### PR TITLE
ensure that "msk" and "result" strings in _getNextSiblingPrefix have the same length

### DIFF
--- a/ipUtils.js
+++ b/ipUtils.js
@@ -473,7 +473,7 @@ const ip = {
 
         if (af === 4) {
             let value = parseInt(msk, 2) + 1;
-            const result = value.toString(2);
+            const result = value.toString(2).padStart(msk.length, "0");
 
             if (msk.slice(0, parentBits) === result.slice(0, parentBits)) {
                 return [this.fromBinary(this._getPaddedNetmask(result, 4), 4), bits, af];


### PR DESCRIPTION
Tiny patch which ensures that "msk" and "result" strings in "_getNextSiblingPrefix" function have the same length. Without this patch the added test seen below would fail:

```
$ diff -u tests.js{~,}
--- tests.js~   2022-11-28 14:11:35.346565591 +0000
+++ tests.js    2022-11-28 14:17:37.155197007 +0000
@@ -96,7 +96,7 @@
         for (let sub of subs) {
             expect(ipUtils.isSubnet(prefix, sub.prefix)).to.equal(true);
         }
-    }).timeout(10000);
+    }).timeout(20000);

     it("subprefix range test - binary (performance)", function () {

@@ -198,10 +198,13 @@
         expect(ipUtils.ipRangeToCidr("216.168.129.0", "216.168.130.255"))
             .to.have.members(["216.168.129.0/24", "216.168.130.0/24"]);

+        expect(ipUtils.ipRangeToCidr("89.219.134.0", "89.219.154.255"))
+            .to.have.members(["89.219.134.0/23", "89.219.136.0/21", "89.219.144.0/21", "89.219.152.0/23", "89.219.154.0/24"]);
+
         expect(ipUtils.ipRangeToCidr("216.168.129.0", "216.168.130.254").sort())
             .to.have.members(["216.168.129.0/24", "216.168.130.0/25", "216.168.130.128/26", "216.168.130.192/27", "216.168.130.224/28", "216.168.130.240/29", "216.168.130.248/30", "216.168.130.252/31", "216.168.130.254/32"].sort());

-    }).timeout(20000);
+    }).timeout(40000);

     it("add cidr", function () {
         expect(ipUtils.addCidr("216.168.129.0"))
@@ -323,4 +326,4 @@
         expect(ipUtils.cidrToRange("2002:db0::/32").join("-")).to.equal("2002:db0:0:0:0:0:0:0-2002:db0:ffff:ffff:ffff:ffff:ffff:ffff");

     });
-});
\ No newline at end of file
+});
$ 
$ mocha tests.js


  Tests
    ✔ subprefix test
    ✔ subprefix range test (11418ms)
    ✔ subprefix range test - binary (performance) (9531ms)
    ✔ sort by prefix length
    ✔ validity
    ✔ equality
    ✔ netmask test - cache mixup
    ✔ expansion
    ✔ range to cidr (4811ms)
    ✔ add cidr
    ✔ to prefix
    ✔ sort IPs
    ✔ sort prefixes v4
    ✔ sort prefixes v6
    ✔ cidr to range


  15 passing (26s)

$ 
```